### PR TITLE
[Feat] 편지 삭제, 즐겨찾기 추가 API 구현

### DIFF
--- a/src/main/java/com/simter/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/simter/apiPayload/code/status/ErrorStatus.java
@@ -32,8 +32,10 @@ public enum ErrorStatus implements BaseCode {
     NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "MEMBER4002", "닉네임은 필수 입니다."),
 
     //종이비행기 관련 에러
-    AIRPLANE_NOT_FOUND(HttpStatus.BAD_REQUEST, "PAPER_AIRPLANE4001", "종이비행기가 없습니다.");
+    AIRPLANE_NOT_FOUND(HttpStatus.BAD_REQUEST, "PAPER_AIRPLANE4001", "종이비행기가 없습니다."),
 
+    //메일 관련 에러
+    MAIL_NOT_FOUND(HttpStatus.BAD_REQUEST, "MAIL4001", "메일이 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/simter/domain/mail/controller/MailController.java
+++ b/src/main/java/com/simter/domain/mail/controller/MailController.java
@@ -2,16 +2,14 @@ package com.simter.domain.mail.controller;
 
 
 import com.simter.apiPayload.ApiResponse;
-import com.simter.domain.airplane.dto.AirplaneGetResponseDto;
-import com.simter.domain.mail.converter.MailConverter;
 import com.simter.domain.mail.dto.MailGetResponseDto;
 import com.simter.domain.mail.service.MailService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -38,6 +36,23 @@ public class MailController {
         MailGetResponseDto response = mailService.getStaredMails(memberId);
         return ApiResponse.onSuccess(response);
     }
+
+    // 편지 즐겨찾기 변경 API (PATCH)
+    @Operation(summary = "편지 즐겨찾기 변경", description = "특정 편지의 '즐겨찾기' 여부를 변경하는 API")
+    @PatchMapping("/mail/star/{mailId}")
+    public ApiResponse<Void> changeStared(@PathVariable Long mailId) {
+        mailService.changeStared(mailId);
+        return ApiResponse.onSuccess(null);
+    }
+
+    // 편지 삭제 API (PATCH)
+    @Operation(summary = "편지 삭제", description = "특정 편지를 삭제하는 API")
+    @GetMapping("/mail/delete/{mailId}")
+    public ApiResponse<Void> deleteMail(@PathVariable Long mailId) {
+        mailService.deleteMail(mailId);
+        return ApiResponse.onSuccess(null);
+    }
+
 
 
 }

--- a/src/main/java/com/simter/domain/mail/dto/MailStarRequestDto.java
+++ b/src/main/java/com/simter/domain/mail/dto/MailStarRequestDto.java
@@ -1,5 +1,0 @@
-package com.simter.domain.mail.dto;
-
-public class MailStarRequestDto {
-
-}

--- a/src/main/java/com/simter/domain/mail/dto/MailStarResponseDto.java
+++ b/src/main/java/com/simter/domain/mail/dto/MailStarResponseDto.java
@@ -1,5 +1,0 @@
-package com.simter.domain.mail.dto;
-
-public class MailStarResponseDto {
-
-}

--- a/src/main/java/com/simter/domain/mail/entity/Mail.java
+++ b/src/main/java/com/simter/domain/mail/entity/Mail.java
@@ -31,10 +31,8 @@ public class Mail {
     @Column(nullable = false, length = 100)
     private String chatbotType;
 
-    @Column(updatable = false)
     private LocalDateTime createdAt;
 
-    @Column(updatable = false)
     private LocalDateTime deletedAt;
 
     @Column(nullable = false)
@@ -47,6 +45,12 @@ public class Mail {
     @ColumnDefault("false")
     private Boolean isStared = false;
 
+    public void setIsStared(Boolean isStared) {
+        this.isStared = isStared;
+    }
 
-
+    public void markAsDeleted() {
+        this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/simter/domain/mail/repository/MailRepository.java
+++ b/src/main/java/com/simter/domain/mail/repository/MailRepository.java
@@ -4,6 +4,7 @@ package com.simter.domain.mail.repository;
 import com.simter.domain.mail.entity.Mail;
 import com.simter.domain.member.entity.Member;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -16,5 +17,6 @@ public interface MailRepository extends JpaRepository<Mail, Long> {
     // 특정 사용자의 즐겨찾기 한 메일 조회
     List<Mail> findByMemberAndIsStaredTrue(Member member);
 
+    Optional<Mail> findById(Long id);
 
 }

--- a/src/main/java/com/simter/domain/mail/service/MailService.java
+++ b/src/main/java/com/simter/domain/mail/service/MailService.java
@@ -9,6 +9,7 @@ import com.simter.domain.mail.entity.Mail;
 import com.simter.domain.mail.repository.MailRepository;
 import com.simter.domain.member.entity.Member;
 import com.simter.domain.member.repository.MemberRepository;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -37,6 +38,22 @@ public class MailService {
 
         List<Mail> mails = mailRepository.findByMemberAndIsStaredTrue(member);
         return mailConverter.convertToMailGetResponseDto(mails);
+    }
+
+    //특정 메일의 즐겨찾기 여부 변경
+    public void changeStared(Long mailId) {
+        Mail mail = mailRepository.findById(mailId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.MAIL_NOT_FOUND));
+        mail.setIsStared(!mail.getIsStared());
+        mailRepository.save(mail);
+    }
+
+    //특정 편지 삭제
+    public void deleteMail(Long mailId) {
+        Mail mail = mailRepository.findById(mailId)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.MAIL_NOT_FOUND));
+        mail.markAsDeleted();
+        mailRepository.save(mail);
     }
 
 


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #35 

## ✍️ 작업 내용 요약
> 편지 삭제, 즐겨찾기 추가 API 구현

## 💡 작업내용
1. 편지 삭제 API 구현
- soft delete
2.  편지 즐겨찾기 추가 API 구현 
- patch로 요청할 때마다 즐겨찾기 추가/삭제
- `is_deleted` true로, `deleted_at` localdatetime으로 업데이트
### 스웨거
|스웨거|
|------|
|<img width="400" alt="image" src="https://github.com/user-attachments/assets/e3304659-5a3d-4eef-89b6-f95bd99fc9b6">|

|편지 즐겨찾기 추가 API|
|------|
|![image](https://github.com/user-attachments/assets/9c99d213-33e9-49d1-9a3c-b53e0fc7d44f)|

|편지 삭제 API|
|------|
|<img width="1075" alt="image" src="https://github.com/user-attachments/assets/dc721a77-2931-4817-8006-49d9014c7169">|
|<img width="979" alt="image" src="https://github.com/user-attachments/assets/b7cb87ce-c5c1-453c-8d45-205d6416714b">|

