### PR TITLE
[Feat] 사용할 챗봇 선택, 챗봇 세션 생성 API 구현 

### DIFF
--- a/src/main/java/com/simter/domain/chatbot/controller/ChatbotController.java
+++ b/src/main/java/com/simter/domain/chatbot/controller/ChatbotController.java
@@ -1,12 +1,19 @@
 package com.simter.domain.chatbot.controller;
 
 import com.simter.apiPayload.ApiResponse;
+import com.simter.config.JwtTokenProvider;
 import com.simter.domain.chatbot.dto.DefaultChatbotRequestDto;
+import com.simter.domain.chatbot.dto.SelectChatbotRequestDto;
+import com.simter.domain.chatbot.dto.SelectChatbotResponseDto;
 import com.simter.domain.chatbot.service.ChatbotService;
 import com.simter.domain.mail.dto.MailDeleteRequestDto;
+import com.simter.domain.member.dto.JwtTokenDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -22,6 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ChatbotController {
 
     private final ChatbotService chatbotService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     //Default 챗봇 변경 API(PATCH)
     @Operation(summary = "Default 챗봇 변경", description = "챗봇 유형을 변경하는 API")
@@ -39,4 +47,14 @@ public class ChatbotController {
         return ApiResponse.onSuccess(response);
     }
 
+    //특정 세션의 챗봇 type 설정(PATCH)
+    @Operation(summary = "특정 세션의 챗봇 설정 변경", description = "사용자의 세션에 해당하는 챗봇 타입을 설정하고 새로운 상담 일지를 생성하는 API")
+    @PatchMapping("/chatbot/session")
+    public ApiResponse<SelectChatbotResponseDto> updateChatbotSession(HttpServletRequest request, @RequestBody SelectChatbotRequestDto selectChatbotRequestDto) {
+
+        JwtTokenDto token = jwtTokenProvider.resolveToken(request);
+        String email = jwtTokenProvider.getEmail(token.getAccessToken());
+        SelectChatbotResponseDto response = chatbotService.selectChatbot(email, selectChatbotRequestDto.getChatbotType());
+        return ApiResponse.onSuccess(response);
+    }
 }

--- a/src/main/java/com/simter/domain/chatbot/controller/ChatbotController.java
+++ b/src/main/java/com/simter/domain/chatbot/controller/ChatbotController.java
@@ -49,8 +49,8 @@ public class ChatbotController {
 
     //특정 세션의 챗봇 type 설정(PATCH)
     @Operation(summary = "특정 세션의 챗봇 설정 변경", description = "사용자의 세션에 해당하는 챗봇 타입을 설정하고 새로운 상담 일지를 생성하는 API")
-    @PatchMapping("/chatbot/session")
-    public ApiResponse<SelectChatbotResponseDto> updateChatbotSession(HttpServletRequest request, @RequestBody SelectChatbotRequestDto selectChatbotRequestDto) {
+    @PostMapping("/chatbot/session")
+    public ApiResponse<SelectChatbotResponseDto> createChatbotSession(HttpServletRequest request, @RequestBody SelectChatbotRequestDto selectChatbotRequestDto) {
 
         JwtTokenDto token = jwtTokenProvider.resolveToken(request);
         String email = jwtTokenProvider.getEmail(token.getAccessToken());

--- a/src/main/java/com/simter/domain/chatbot/dto/SelectChatbotRequestDto.java
+++ b/src/main/java/com/simter/domain/chatbot/dto/SelectChatbotRequestDto.java
@@ -1,0 +1,12 @@
+package com.simter.domain.chatbot.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SelectChatbotRequestDto {
+    String chatbotType;
+}

--- a/src/main/java/com/simter/domain/chatbot/dto/SelectChatbotResponseDto.java
+++ b/src/main/java/com/simter/domain/chatbot/dto/SelectChatbotResponseDto.java
@@ -1,0 +1,14 @@
+package com.simter.domain.chatbot.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SelectChatbotResponseDto {
+
+    Long counselingId;
+
+}

--- a/src/main/java/com/simter/domain/chatbot/entity/CounselingLog.java
+++ b/src/main/java/com/simter/domain/chatbot/entity/CounselingLog.java
@@ -33,13 +33,13 @@ public class CounselingLog {
     @Column(updatable = false)
     private LocalDateTime endedAt;
 
-    @Column(nullable = false, length = 500)
+    @Column(length = 500)
     private String summary;
 
-    @Column(nullable = false, length = 500)
+    @Column(length = 500)
     private String suggestion;
 
-    @Column(nullable = false, length = 100)
+    @Column(length = 100)
     private String title;
 
     public void setMember(Long memberId) {

--- a/src/main/java/com/simter/domain/chatbot/entity/CounselingLog.java
+++ b/src/main/java/com/simter/domain/chatbot/entity/CounselingLog.java
@@ -42,5 +42,20 @@ public class CounselingLog {
     @Column(nullable = false, length = 100)
     private String title;
 
+    public void setMember(Long memberId) {
+        this.member = member;
+    }
+
+    public void setChatbotType(String chatbotType) {
+        this.chatbotType = chatbotType;
+    }
+
+    public void setStartedAt(LocalDateTime startedAt) {
+        this.startedAt = startedAt;
+    }
+
+    public void setEndedAt(LocalDateTime endedAt) {
+        this.endedAt = endedAt;
+    }
 
 }

--- a/src/main/java/com/simter/domain/chatbot/repository/ChatbotRepository.java
+++ b/src/main/java/com/simter/domain/chatbot/repository/ChatbotRepository.java
@@ -1,5 +1,5 @@
 package com.simter.domain.chatbot.repository;
 
-public class ChatbotRepository {
+public interface ChatbotRepository {
 
 }

--- a/src/main/java/com/simter/domain/chatbot/repository/CounselingLogRepository.java
+++ b/src/main/java/com/simter/domain/chatbot/repository/CounselingLogRepository.java
@@ -1,0 +1,11 @@
+package com.simter.domain.chatbot.repository;
+
+import com.simter.domain.chatbot.entity.CounselingLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CounselingLogRepository extends JpaRepository<CounselingLog, Long> {
+
+
+}

--- a/src/main/java/com/simter/domain/chatbot/service/ChatbotService.java
+++ b/src/main/java/com/simter/domain/chatbot/service/ChatbotService.java
@@ -2,8 +2,12 @@ package com.simter.domain.chatbot.service;
 
 import com.simter.apiPayload.code.status.ErrorStatus;
 import com.simter.apiPayload.exception.handler.ErrorHandler;
+import com.simter.domain.chatbot.dto.SelectChatbotResponseDto;
+import com.simter.domain.chatbot.entity.CounselingLog;
+import com.simter.domain.chatbot.repository.CounselingLogRepository;
 import com.simter.domain.member.entity.Member;
 import com.simter.domain.member.repository.MemberRepository;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -12,6 +16,7 @@ import org.springframework.stereotype.Service;
 public class ChatbotService {
 
    private final MemberRepository memberRepository;
+   private final CounselingLogRepository counselingLogRepository;
 
     //사용자의 default 챗봇 변경
     public void updateDefaultChatbot(Long memberId, String ChatbotType) {
@@ -29,4 +34,18 @@ public class ChatbotService {
         return member.getChatbot();
     }
 
+    //챗봇 세션을 시작을 시작하고 해당 세션의 챗봇 설정
+    public SelectChatbotResponseDto selectChatbot(String email, String chatbotType) {
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new ErrorHandler(ErrorStatus.MEMBER_NOT_FOUND));
+
+        CounselingLog log = CounselingLog.builder()
+                .member(member)
+                .chatbotType(chatbotType)
+                .startedAt(LocalDateTime.now())
+                .build();
+
+        log = counselingLogRepository.save(log);
+        return new SelectChatbotResponseDto(log.getId());
+    }
 }

--- a/src/test/java/com/simter/domain/chatbot/controller/ChatbotControllerTest.java
+++ b/src/test/java/com/simter/domain/chatbot/controller/ChatbotControllerTest.java
@@ -1,0 +1,76 @@
+package com.simter.domain.chatbot.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.simter.domain.chatbot.dto.SelectChatbotResponseDto;
+import com.simter.domain.chatbot.repository.CounselingLogRepository;
+import com.simter.domain.chatbot.service.ChatbotService;
+import com.simter.domain.member.entity.Member;
+import com.simter.domain.member.repository.MemberRepository;
+import jakarta.transaction.Transactional;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ChatbotControllerTest {
+
+    @Mock
+    private ChatbotService chatbotService;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+
+    void 사용자의_기본_챗봇_변경() {
+    }
+
+    @Test
+    void 사용자의_기본_챗봇_조회() {
+        // Given
+        Member member = Member.builder()
+                .id(1L)
+                .email("test@gmail.com")
+                .nickname("테스트_유저")
+                .build();
+        member.setChatbot("반바니");
+
+        when(chatbotService.getDefaultChatbot(1L)).thenReturn("반바니");
+
+        // When
+        String defaultChatbot = chatbotService.getDefaultChatbot(member.getId());
+
+        // Then
+        assertEquals("반바니", defaultChatbot);
+
+        // 불필요한 스터빙은 제거합니다.
+    }
+
+    @Test
+    void 챗봇_설정_및_챗봇_세션_등록() {
+//        // Given
+//        Member member = Member.builder()
+//                .id(1L)
+//                .email("test@gmail.com")
+//                .nickname("테스트_유저")
+//                .build();
+//
+//        when(memberRepository.findByEmail("test@gmail.com"))
+//                .thenReturn(Optional.of(member));
+//
+//        // When
+//        SelectChatbotResponseDto responseDto = chatbotService.selectChatbot("test@gmail.com", "반바니");
+//
+//        // Then
+//        assertNotNull(responseDto);
+//        assertEquals(1L, responseDto.getCounselingId());
+    }
+}


### PR DESCRIPTION
## #️⃣ 관련 이슈
- #49 

## ✍️ 작업 내용 요약
> 사용할 챗봇 선택, 챗봇 세션 생성 API 구현 

## 💡 작업내용
1. 챗봇에서 사용할 챗봇 선택 API 구현
2. 요청 보내면 챗봇 세션 생성되고 아이디 반환

## 🏞 요청
|요청 API|
|------|
|Postman|
|<img width="1069" alt="image" src="https://github.com/user-attachments/assets/542637c8-d356-4540-b7a0-113ee29bfe44">|
|데이터 생성|
|<img width="1366" alt="image" src="https://github.com/user-attachments/assets/25b95a03-eb05-4e71-8371-9c7f90fa95f3">|




